### PR TITLE
Consolidate and contribute back changes from QHack 2022

### DIFF
--- a/qcircuits/QCircuit.py
+++ b/qcircuits/QCircuit.py
@@ -29,6 +29,14 @@ class QCircuit:
 		
 		return self.circuit, self.qubits
 
+	def pqc_circuit(self):
+		self.qubits  = cirq.GridQubit.rect(self.n_qubits, 1)
+		self.circuit = cirq.Circuit()
+
+		self.PQC()(self.circuit, self.qubits, n_layers = self.n_layers, n_qubits = self.n_qubits)
+		
+		return self.circuit, self.qubits
+
 	def IEC(self):
 		'''information encoding circuit'''
 		return getattr(qcircuits, self.metadata['qc_iec_dict'][self.IEC_id])
@@ -75,6 +83,14 @@ class QCircuit:
 			n_params = 2*self.n_qubits - 1
 		elif self.PQC_id == '10_local':
 			n_params = self.n_qubits*self.n_layers+1
+		elif self.PQC_id == '10_2des':
+			n_params = self.n_qubits*(self.n_layers+1)
+		elif self.PQC_id == '10_2':
+			n_params = self.n_qubits*(self.n_layers+1)
+		elif self.PQC_id == '10_3':
+			n_params = self.n_qubits*(self.n_layers+1)
+		elif self.PQC_id == '10_identity':
+			n_params = self.n_qubits*(self.n_layers+1)*2
 		else:
 			raise ValueError('PQC weights not defined')
 		return n_params

--- a/qcircuits/circuits_metadata.json
+++ b/qcircuits/circuits_metadata.json
@@ -72,15 +72,18 @@
         "feature_map": "ZZFeatureMap",
         "yz_arccos": "yz_arccos"
     },
-    "qc_pqc_dict" : {
+    "qc_pqc_dict": {
         "19": "qc19_pqc",
         "15": "qc15_pqc",
-        "14"  : "qc14_pqc",
-        "10"  : "qc10_pqc",
-        "10P"  : "qc10P_pqc",
-        "7"  : "qc7_pqc",
-        "6"  : "qc6_pqc",
-        "3"  : "qc3_pqc",
+        "14": "qc14_pqc",
+        "10": "qc10_pqc",
+        "10P": "qc10P_pqc",
+        "10_2des": "qc10_pqc_two_design",
+        "10_2": "qc10_2_pqc",
+        "10_3": "qc10_3_pqc",
+        "7": "qc7_pqc",
+        "6": "qc6_pqc",
+        "3": "qc3_pqc",
         "15_4": "qc15_4_pqc",
         "15_6": "qc15_6_pqc",
         "14_4": "qc14_4_pqc",
@@ -97,6 +100,7 @@
         "generic": "generic_pqc",
         "TTN": "TTN",
         "MPS": "MPS",
-        "10_local"  : "qc10_pqc_local"
+        "10_local": "qc10_pqc_local",
+        "10_identity": "qc10_pqc_identity"
     }
 }


### PR DESCRIPTION
Hi Cenk,

First off -- thank you for supporting us during QHack 2022.

I hope this contribution back to QTrkX will be a return on your investment. You're welcome to take all, some, or none of the changes depending on what you think they would benefit the project.

For reference, our final QHack submission is [here](https://github.com/XanaduAI/QHack/issues/141), which includes our report. 

This PR contains the following changes:
* Additional ansatze:
  * '10_2' that we found improved precision by 6% (our main finding) when compared against '10' on a smaller dataset
  * '10_3' that also performed as well as '10', but randomly chooses rx, ry, and rz gates, so may be interesting to analyze
  * '10' w/ the two-design you mentioned might be helpful (removes the circular entanglement)
  * A version of '10' that makes use of the identity blocks as mentioned in this [TF tutorial](https://www.tensorflow.org/quantum/tutorials/barren_plateaus), which is originally from [Grant, 2019](https://quantum-journal.org/papers/q-2019-12-09-214/pdf/)
  * A utility function that can generate versions of identity blocks for any of the other ansatze
* Replacement of `sigmoid` activations with `relu` followed by rescaling layers ([0-1] range), which removes the immediate vanishing gradients that show up in the model

For the final point, please note that only `qc10_pqc` has been modified to work with the utility function. For any others you'd like to try, you will need to:
* support a `symbol_offset` optional parameter
* return the `symbols` from the PQC from the function

See `qc10_pqc_identity` for an example.

Also, we have a notebook that is an adaptation of the TensorFlow tutorial mentioned above that works to analyze the gradient variance in various ansatze (it loads this info from the `circuits_metadata.json`. We found this useful to quickly analyze the existing PQCs outside of the training pipeline. This notebook is not included in this PR, but you can find a copy [here](https://github.com/amirebrahimi/qtrkx-gnn-tracking/blob/contrib-prep/barren_plateaus.ipynb).

An example graph:
![image](https://user-images.githubusercontent.com/904110/155826682-05b69d7b-18ae-4bce-b106-89f5f848e23b.png)
